### PR TITLE
Fix category

### DIFF
--- a/rix1337/ssh2socks.xml
+++ b/rix1337/ssh2socks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Container>
   <Beta>False</Beta>
-  <Category>Proxy: Socks</Category>
+  <Category>Network:Proxy</Category>
   <Date>2015-12-01</Date>
   <Changes>
     -Initial Release


### PR DESCRIPTION
Categories are specific and the only acceptable categories are generated by the categorizer plugin.  Any deviation from what the plugin generates means that the container will not display under the category.
